### PR TITLE
fix: type annotation issue with Python versions before 3.11

### DIFF
--- a/examples/advanced/clear_inventory.py
+++ b/examples/advanced/clear_inventory.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():

--- a/examples/advanced/reward_top_users.py
+++ b/examples/advanced/reward_top_users.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():
@@ -10,8 +11,8 @@ async def main():
 
     # Fetch guild leaderboard, by default it will fetch 1000 users
     leaderboard = await client.get_guild_leaderboard(guild_id)  # {"limit": ...}
-    
-    # Or fetch whole leaderboard 
+
+    # Or fetch whole leaderboard
     leaderboard = await client.get_guild_leaderboard_all(guild_id)
 
     # Add items to the leaderboard users

--- a/examples/balance.py
+++ b/examples/balance.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():

--- a/examples/guild.py
+++ b/examples/guild.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():

--- a/examples/inventory.py
+++ b/examples/inventory.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():

--- a/examples/leaderboard.py
+++ b/examples/leaderboard.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():

--- a/examples/permissions.py
+++ b/examples/permissions.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():

--- a/examples/store.py
+++ b/examples/store.py
@@ -1,5 +1,6 @@
-from unbelievaboat import Client
 import asyncio
+
+from unbelievaboat import Client
 
 
 async def main():

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import find_packages, setup
 from pathlib import Path
 
+from setuptools import find_packages, setup
 
 cwd = Path(__file__).parent
 long_description = (cwd / "README.md").read_text()

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "aiohttp ~= 3.8.4",
+        "typing_extensions ~= 4.12.2",
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/unbelievaboat/Client.py
+++ b/unbelievaboat/Client.py
@@ -5,13 +5,13 @@ import aiohttp
 from .RequestHandler import RequestHandler
 from .structures import (
     Guild,
-    UserInventory,
     InventoryItem,
     Leaderboard,
     Permission,
     Store,
     StoreItem,
     UserBalance,
+    UserInventory,
 )
 from .util import to_snake_case_deep
 

--- a/unbelievaboat/RequestHandler.py
+++ b/unbelievaboat/RequestHandler.py
@@ -1,9 +1,9 @@
 import asyncio
+import re
 import time
 from typing import Any, Dict, Optional
 
 from .errors import APIError, HTTPError
-import re
 
 
 class RequestHandler:
@@ -19,9 +19,11 @@ class RequestHandler:
         major_params = ["guilds"]
         route = re.sub(
             r"/([a-z-]+)/(?:(\d+))",
-            lambda match: match.group()
-            if match.group(1) in major_params
-            else f"/{match.group(1)}/:id",
+            lambda match: (
+                match.group()
+                if match.group(1) in major_params
+                else f"/{match.group(1)}/:id"
+            ),
             endpoint,
         )
         return f"{method}/{route}"

--- a/unbelievaboat/structures/Permission.py
+++ b/unbelievaboat/structures/Permission.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union
+from typing import Dict, Union, List
 
 
 class Permission:
@@ -20,7 +20,7 @@ class Permission:
                 )
         return json
 
-    def has(self, permissions: Union[str, list[str]]) -> bool:
+    def has(self, permissions: Union[str, List[str]]) -> bool:
         if isinstance(permissions, list):
             return all(
                 bool(self.allow & getattr(self.__class__, perm)) for perm in permissions

--- a/unbelievaboat/structures/Permission.py
+++ b/unbelievaboat/structures/Permission.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, List
+from typing import Dict, List, Union
 
 
 class Permission:

--- a/unbelievaboat/structures/UserBalance.py
+++ b/unbelievaboat/structures/UserBalance.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional
+
 from typing_extensions import Self
 
 

--- a/unbelievaboat/structures/UserBalance.py
+++ b/unbelievaboat/structures/UserBalance.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Self
+from typing import Any, Dict, Optional
+from typing_extensions import Self
 
 
 class UserBalance:

--- a/unbelievaboat/structures/UserInventory.py
+++ b/unbelievaboat/structures/UserInventory.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Dict, List, Optional, Self, Union
+from typing import Dict, List, Optional, Union
+from typing_extensions import Self
 
 from .items import InventoryItem, StoreItem
 

--- a/unbelievaboat/structures/UserInventory.py
+++ b/unbelievaboat/structures/UserInventory.py
@@ -1,5 +1,6 @@
 import asyncio
 from typing import Dict, List, Optional, Union
+
 from typing_extensions import Self
 
 from .items import InventoryItem, StoreItem

--- a/unbelievaboat/structures/__init__.py
+++ b/unbelievaboat/structures/__init__.py
@@ -1,11 +1,10 @@
 from .Guild import Guild
+from .items import *
 from .Leaderboard import Leaderboard
 from .Permission import Permission
+from .Store import Store
 from .UserBalance import UserBalance
 from .UserInventory import UserInventory
-from .Store import Store
-
-from .items import *
 
 __all__ = [
     "Guild",

--- a/unbelievaboat/structures/items/InventoryItem.py
+++ b/unbelievaboat/structures/items/InventoryItem.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional
+
 from typing_extensions import Self
 
 from .BaseItem import BaseItem

--- a/unbelievaboat/structures/items/InventoryItem.py
+++ b/unbelievaboat/structures/items/InventoryItem.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Self
+from typing import Any, Dict, Optional
+from typing_extensions import Self
 
 from .BaseItem import BaseItem
 

--- a/unbelievaboat/structures/items/StoreItem.py
+++ b/unbelievaboat/structures/items/StoreItem.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from typing import Any, Dict, Self
+from typing import Any, Dict
+from typing_extensions import Self
 
 from .BaseItem import BaseItem
 

--- a/unbelievaboat/structures/items/StoreItem.py
+++ b/unbelievaboat/structures/items/StoreItem.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Any, Dict
+
 from typing_extensions import Self
 
 from .BaseItem import BaseItem

--- a/unbelievaboat/util/SnakeCaseConventer.py
+++ b/unbelievaboat/util/SnakeCaseConventer.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Union, Dict, List
+from typing import Any, Dict, List, Union
 
 
 def to_snake_case_deep(

--- a/unbelievaboat/util/__init__.py
+++ b/unbelievaboat/util/__init__.py
@@ -1,5 +1,5 @@
-from .SnakeCaseConventer import to_snake_case_deep
 from .Constants import *
+from .SnakeCaseConventer import to_snake_case_deep
 
 __all__ = [
     "to_snake_case_deep",


### PR DESCRIPTION
When running `python3 -m unbelievaboat` from an appropriate venv for Python 3.8 this is returned:

```
Traceback (most recent call last):
  File "/home/sion/anaconda3/envs/Python3-8/lib/python3.8/runpy.py", line 185, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/home/sion/anaconda3/envs/Python3-8/lib/python3.8/runpy.py", line 144, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/home/sion/anaconda3/envs/Python3-8/lib/python3.8/runpy.py", line 111, in _get_module_details
    __import__(pkg_name)
  File "/home/sion/Toybox/unbelievaboat/unbelievaboat/__init__.py", line 1, in <module>
    from .Client import Client
  File "/home/sion/Toybox/unbelievaboat/unbelievaboat/Client.py", line 6, in <module>
    from .structures import (
  File "/home/sion/Toybox/unbelievaboat/unbelievaboat/structures/__init__.py", line 2, in <module>
    from .Leaderboard import Leaderboard
  File "/home/sion/Toybox/unbelievaboat/unbelievaboat/structures/Leaderboard.py", line 3, in <module>
    from .UserBalance import UserBalance
  File "/home/sion/Toybox/unbelievaboat/unbelievaboat/structures/UserBalance.py", line 1, in <module>
    from typing import Any, Dict, Optional, Self
ImportError: cannot import name 'Self' from 'typing' (/home/sion/anaconda3/envs/Python3-8/lib/python3.8/typing.py)
```

When the expected output is:

```
/home/sion/anaconda3/envs/Python3-8/bin/python3: No module named unbelievaboat.__main__; 'unbelievaboat' is a package and cannot be directly executed
```

This is a result of the using Type annotation created in a version after the running version of Python. 
Specifically typing.Self was introduced in 3.11, as this package targets 3.8+ this needs to be implemented via typing-extensions. Please see [docs.python.org/3.11/library/typing.html#typing.Self](https://docs.python.org/3.11/library/typing.html#typing.Self) for more information. 